### PR TITLE
Clarifying data set used in case study

### DIFF
--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -17,7 +17,7 @@ Categorical features often are a key part of many modern datasets in different i
 
 ## Case study
 
-We'll demonstrate how to use `cattonum` by predicting flight delays (`dep_delay`) in the the `flights` dataset using random forests built with `ranger`.
+We'll demonstrate how to use `cattonum` by predicting flight delays (`dep_delay`) in the the `nycflights13::flights` dataset using random forests built with `ranger`.
 
 ```{r}
 library(nycflights13)


### PR DESCRIPTION
Referencing the `nycflights13::flights` data set in the same way as the `dplyr` vignette (https://github.com/tidyverse/dplyr/blob/master/vignettes/dplyr.Rmd)