### PR TITLE
using expect_equivalent() instead of expect_equal()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/tests/testthat/test-mean.R
+++ b/tests/testthat/test-mean.R
@@ -60,11 +60,11 @@ test_that("catto_mean: one tibble training column.", {
   num_tests <- length(one_encoded)
 
   for (i in seq(from = 1, to = num_tests / 2)) {
-    expect_equal(one_encoded[[i]], expected_x1_tbl_fact)
+    expect_equivalent(one_encoded[[i]], expected_x1_tbl_fact)
   }
 
   for (i in seq(from = num_tests / 2 + 1, to = num_tests)) {
-    expect_equal(one_encoded[[i]], expected_x1_tbl_char)
+    expect_equivalent(one_encoded[[i]], expected_x1_tbl_char)
   }
 })
 
@@ -95,7 +95,7 @@ test_that("catto_mean() correctly encodes tibble with logicals.", {
     x2 = c(35 / 3, 35 / 3, NA, 12, 12, 35 / 3)
   )
 
-  expect_equal(
+  expect_equivalent(
     catto_mean(tbl_logi, response = "y"),
     tbl_logi_expected
   )

--- a/tests/testthat/test-median.R
+++ b/tests/testthat/test-median.R
@@ -57,11 +57,11 @@ test_that("catto_median(): one tibble training column.", {
   num_tests <- length(one_encoded)
 
   for (i in seq(from = 1, to = num_tests / 2)) {
-    expect_equal(one_encoded[[i]], expected_x1_tbl_fact)
+    expect_equivalent(one_encoded[[i]], expected_x1_tbl_fact)
   }
 
   for (i in seq(from = num_tests / 2 + 1, to = num_tests)) {
-    expect_equal(one_encoded[[i]], expected_x1_tbl_char)
+    expect_equivalent(one_encoded[[i]], expected_x1_tbl_char)
   }
 })
 


### PR DESCRIPTION
Using `expect_equivalent()` instead of `expect_equal()` so that the test succeeds when one is a data frame and the other is a tibble with the same data. 

This should work against both cran version of `dplyr` and also the 1.0.0 version that is about to be released soon. 

Please consider releasing. 